### PR TITLE
Fix `suppress_warnings` syntax for `SPHINXOPTS`

### DIFF
--- a/docs/guides/contribute.md
+++ b/docs/guides/contribute.md
@@ -81,7 +81,7 @@ make SPHINXOPTS="OPTION VALUE" BUILDER
 The following example shows how to clean then build a live HTML preview of the documentation while suppressing syntax highlighting failures.
 
 ```shell
-make SPHINXOPTS="-D suppress_warnings=['misc.highlighting_failure']" clean livehtml
+make SPHINXOPTS="-D suppress_warnings='misc.highlighting_failure'" clean livehtml
 ```
 
 You can also pass options to vale in the `VALEOPTS` environment variable.

--- a/news/47.documentation
+++ b/news/47.documentation
@@ -1,0 +1,1 @@
+Fix `suppress_warnings` syntax for `SPHINXOPTS`. @stevepiercy


### PR DESCRIPTION


<!-- readthedocs-preview plone-sphinx-theme start -->
----
📚 Documentation preview 📚: https://plone-sphinx-theme--47.org.readthedocs.build/

<!-- readthedocs-preview plone-sphinx-theme end -->